### PR TITLE
Warnings removed so it can be built under FSF GNAT 9 (Ubuntu 20.04)

### DIFF
--- a/core.gpr
+++ b/core.gpr
@@ -6,7 +6,9 @@ project Core is
    for Object_Dir use "obj";
 
    package Compiler is
-      for Default_Switches ("Ada") use Config.switch_ada_default_conf & ("-gnatg");
+      for Default_Switches ("Ada") use Config.switch_ada_default_conf & ("-gnatg",
+                                                                         "-gnatw_A" --  Disable warnings on "anonymous access type allocators"
+                                                                        );
    end Compiler;
 
    package Documentation is

--- a/src/io/lse-io-export_factory.adb
+++ b/src/io/lse-io-export_factory.adb
@@ -35,7 +35,6 @@ package body LSE.IO.Export_Factory is
                    Value : String;
                    Path  : String)
    is
-      use LSE.Model.IO.Drawing_Area.PostScript;
 
       Found : Boolean := False;
    begin
@@ -59,7 +58,6 @@ package body LSE.IO.Export_Factory is
             return ".ps";
       end case;
 
-      raise Unknown_Drawing_Area_Type;
    end Get_Extension;
 
 end LSE.IO.Export_Factory;

--- a/src/model/grammar/lse-model-grammar-symbol_utils.ads
+++ b/src/model/grammar/lse-model-grammar-symbol_utils.ads
@@ -46,6 +46,5 @@ package LSE.Model.Grammar.Symbol_Utils is
        (
         Element_Type => Ptr.Holder
        );
-   use P_List;
 
 end LSE.Model.Grammar.Symbol_Utils;

--- a/src/model/io/lse-model-io-drawing_area_factory.adb
+++ b/src/model/io/lse-model-io-drawing_area_factory.adb
@@ -35,7 +35,6 @@ package body LSE.Model.IO.Drawing_Area_Factory is
                    Value : String;
                    Path  : String)
    is
-      use LSE.Model.IO.Drawing_Area.PostScript;
 
       Unknown_Drawing_Area_Type : exception;
 

--- a/src/model/io/lse-model-io-turtle.adb
+++ b/src/model/io/lse-model-io-turtle.adb
@@ -333,7 +333,6 @@ package body LSE.Model.IO.Turtle is
 
    procedure Configure (This : in out Instance)
    is
-      use Ada.Strings;
    begin
       if not This.Dry_Run then
          This.Make_Offset;
@@ -367,7 +366,6 @@ package body LSE.Model.IO.Turtle is
 
    procedure Forward (This : in out Instance; Trace : Boolean := False)
    is
-      use Ada.Float_Text_IO;
       use Ada.Numerics.Elementary_Functions;
 
       ------------------------

--- a/src/model/l_system/lse-model-l_system-growth_rule_utils.ads
+++ b/src/model/l_system/lse-model-l_system-growth_rule_utils.ads
@@ -41,6 +41,5 @@ package LSE.Model.L_System.Growth_Rule_Utils is
        (
         Element_Type => Instance'Class
        );
-   use P_List;
 
 end LSE.Model.L_System.Growth_Rule_Utils;

--- a/src/presenter/lse-presenter-presenter.adb
+++ b/src/presenter/lse-presenter-presenter.adb
@@ -41,7 +41,6 @@ package body LSE.Presenter.Presenter is
    --  Constructor
    procedure Initialize (This : out Instance)
    is
-      use Ada.Directories;
       use Glib.Convert;
       use Gtk.Builder;
       use LSE.Model.IO.Turtle;
@@ -127,12 +126,10 @@ package body LSE.Presenter.Presenter is
                      Fg_Rgba     : Gdk_RGBA;
                      Have_Bg     : Boolean)
    is
-      use Glib.Convert;
       use LSE.IO.Export_Factory;
       use LSE.Model.IO.Drawing_Area.Drawing_Area_Ptr;
       use LSE.Model.IO.Turtle;
       use LSE.Utils.Colors;
-      use LSE.View.View;
 
       Turtle : LSE.Model.IO.Turtle_Utils.Holder;
       Medium : LSE.Model.IO.Drawing_Area.Drawing_Area_Ptr.Holder;

--- a/src/utils/lse-utils-colors.adb
+++ b/src/utils/lse-utils-colors.adb
@@ -146,8 +146,6 @@ package body LSE.Utils.Colors is
 
    function RGB_To_Hex_String (R, G, B : Natural) return String
    is
-      use Ada.Strings;
-      use Ada.Strings.Fixed;
 
       Rs : String (1 .. 6);
       Gs : String (1 .. 6);

--- a/src/utils/lse-utils-colors.ads
+++ b/src/utils/lse-utils-colors.ads
@@ -83,6 +83,5 @@ private
 
    package Formatted_IO is
      new Ada.Text_IO.Editing.Decimal_Output (Fixed_Point);
-   use Formatted_IO;
 
 end LSE.Utils.Colors;

--- a/src/utils/lse-utils-utils.ads
+++ b/src/utils/lse-utils-utils.ads
@@ -42,9 +42,7 @@ package LSE.Utils.Utils is
 
    package Formatted_IO is
      new Ada.Text_IO.Editing.Decimal_Output (Fixed_Point);
-   use Formatted_IO;
 
    package US_Ptr is new Ada.Containers.Indefinite_Holders (Unbounded_String);
-   use US_Ptr;
 
 end LSE.Utils.Utils;

--- a/src/view/lse-view-view.adb
+++ b/src/view/lse-view-view.adb
@@ -51,7 +51,6 @@ with LSE.IO.Drawing_Area;
 with LSE.Model.IO.Drawing_Area.Drawing_Area_Ptr;
 with LSE.Model.IO.Text_File;
 with LSE.View.Callbacks;
-with LSE.View.View_Ptr;
 
 package body LSE.View.View is
 
@@ -60,12 +59,9 @@ package body LSE.View.View is
    is
       pragma Unreferenced (Presenter);
       use Ada.Text_IO;
-      use Gtk.Button;
       use Gtk.Image_Menu_Item;
       use Gtk.Tool_Button;
-      use LSE.Model.IO.Drawing_Area.Drawing_Area_Ptr;
       use LSE.View.Callbacks;
-      use LSE.View.View_Ptr;
 
       Bar_Menu_Item  : Gtk_Image_Menu_Item;
       Icon_Menu_Item : Gtk_Tool_Button;
@@ -451,7 +447,6 @@ package body LSE.View.View is
       use Gtk.Dialog;
       use Gtk.File_Chooser;
       use Gtk.File_Chooser_Dialog;
-      use LSE.Model.IO.Text_File;
 
       Unknown_Color : exception;
 
@@ -594,8 +589,6 @@ package body LSE.View.View is
       use Gtk.Button;
       use Gtk.Check_Button;
       use Gtk.Dialog;
-      use Gtk.Message_Dialog;
-      use LSE.View.View;
       use LSE.View.Callbacks;
 
       Builder : Gtk_Builder;

--- a/src/view/lse-view-view.ads
+++ b/src/view/lse-view-view.ads
@@ -185,6 +185,5 @@ private
    use P_Handlers_Widget;
    use P_Handlers_User_Callback_String;
    use P_Handlers_User_Callback_Color;
-   use P_Handlers_User_Callback_Cairo;
 
 end LSE.View.View;


### PR DESCRIPTION
Different compiler versions raise different warnings, so the flag for treating
warnings as errors is a bit problematic for distribution.